### PR TITLE
Module defaults

### DIFF
--- a/lib/src/open.client/core/mvc/module.coffee
+++ b/lib/src/open.client/core/mvc/module.coffee
@@ -67,7 +67,7 @@ class Module extends Base
   init: (options = {}) -> 
       
       # Construct MVC index.
-      get = Module.requireMvcIndex
+      get = Module.requirePart
       @index =
           models:      get @require.model
           views:       get @require.view
@@ -80,24 +80,26 @@ class Module extends Base
 # STATIC METHODS
 
 ###
-Attempts to get the index within the specified MVC folder.
+Attempts to get an MVC part using the given require function - 
+invoking it as a module init if it's a function
 CONVENTION: 
     If the index returns a function, rather than a simple object-literal
     the module assumes it wants to be initialized with this, the parent module
     and invokes it passing the module as the parameter.
 
-@param fnRequirePart: The require-part function (see module.require.*)
-@returns the index or null if the MVC part does not have an index defined.
+@param fnRequire: The require-part function (see module.require.*)
+@param name:      The name of the module.  Default is [index] (empty string).
+@returns the module or null if the MVC part does not exist.
 ###
-Module.requireMvcIndex = (fnRequirePart) -> 
+Module.requirePart = (fnRequire, name = '') -> 
     
     # Silently try to get the 'index' of the MVC part.
-    index = fnRequirePart '', throw: false
+    index = fnRequire name, throw: false
     return index unless index?
     
     # If the [index] is a funciton, it is expected that this is an initialization
     # function.  Invoke it passing in the module.
-    index(fnRequirePart.module) if _.isFunction(index)
+    index = index(fnRequire.module) if _.isFunction(index)
     
     # Finish up.
     index

--- a/lib/src/open.client/core/mvc/module.coffee
+++ b/lib/src/open.client/core/mvc/module.coffee
@@ -46,9 +46,14 @@ class Module extends Base
   index: null # Set in Init method.
   
   ###
-  An index of helper methods for requiring modules within the MVC folder structure of the module.
+  An index of helper methods for requiring sub-modules within the MVC folder structure of the module.
+  This is an index of functions:
+     - model
+     - view
+     - controller
+  
   For example, to retrieve a module named 'foo' within the /models folder:
-    foo = module.require.model('foo')
+      foo = module.require.model('foo')
   ###    
   require: null # Set in constructor.
   
@@ -62,7 +67,8 @@ class Module extends Base
   init: (options = {}) -> 
       
       # Construct MVC index.
-      get = (fn) -> fn '', throw:false
+      # get = (fn) -> fn '', throw:false
+      get = Module.requireMvcIndex
       @index =
           models:      get @require.model
           views:       get @require.view
@@ -73,7 +79,24 @@ class Module extends Base
 
 
 # STATIC METHODS
-# Module.getPart = (module) -> 
+
+###
+Attempts to get the index within the specified MVC folder.
+CONVENTION: 
+    If the index returns a function, rather than a simple object-literal
+    the module assumes it wants to be initialized with this, the parent module
+    and invokes it passing the module as the parameter.
+
+@param fnRequirePart: The require-part function (see module.require.*)
+@returns the index or null if the MVC part does not have an index defined.
+###
+Module.requireMvcIndex = (fnRequirePart) -> 
+    
+    # Silently try to get the 'index' of the MVC part.
+    index = fnRequirePart '', throw: false
+    
+    
+
 
 # EXPORT
 module.exports = Module

--- a/lib/src/open.client/core/mvc/module.coffee
+++ b/lib/src/open.client/core/mvc/module.coffee
@@ -3,7 +3,7 @@ Base     = using 'base'
 common   = using '/mvc/_common'
 util     = using 'util'
 
-module.exports = class Module extends Base
+class Module extends Base
   tryRequire: util.tryRequire
   
   ###
@@ -13,15 +13,17 @@ module.exports = class Module extends Base
   constructor: (@modulePath) -> 
       super
       _require = (dir) => 
-          return (name = '', options = {}) => 
+          
+          # Require statement scoped within the given directory.
+          requirePart = (name = '', options = {}) => 
               options.throw ?= true
               @tryRequire "#{@modulePath}/#{dir}/#{name}", options
-      
-      ###
-      An index of helper methods for requiring modules within the MVC folder structure of the module.
-      For example, to retrieve a module named 'foo' within the /models folder:
-        foo = module.require.model('foo')
-      ###    
+          
+          # Store reference to the module on the [require] function.
+          requirePart.module = @
+          requirePart
+          
+      # Store [require] part functions.
       @require = 
           model:      _require 'models'
           view:       _require 'views'
@@ -35,6 +37,22 @@ module.exports = class Module extends Base
   rootView: null
   
   ###
+  An index of the convention based MVC structures within the module.
+  The object has the form:
+    - models
+    - views
+    - controllers
+  ###
+  index: null # Set in Init method.
+  
+  ###
+  An index of helper methods for requiring modules within the MVC folder structure of the module.
+  For example, to retrieve a module named 'foo' within the /models folder:
+    foo = module.require.model('foo')
+  ###    
+  require: null # Set in constructor.
+  
+  ###
   Initializes the module (overridable).
   @param options
           - within: The CSS selector, DOM element, JQuery Object or [View] to initialize 
@@ -46,9 +64,17 @@ module.exports = class Module extends Base
       # Construct MVC index.
       get = (fn) -> fn '', throw:false
       @index =
-          models: get @require.model
-          views: get @require.view
+          models:      get @require.model
+          views:       get @require.view
           controllers: get @require.controller
   
       # Translate [within] option to jQuery object.
       options.within = util.toJQuery(options.within)
+
+
+# STATIC METHODS
+# Module.getPart = (module) -> 
+
+# EXPORT
+module.exports = Module
+

--- a/lib/src/open.client/core/mvc/module.coffee
+++ b/lib/src/open.client/core/mvc/module.coffee
@@ -67,7 +67,6 @@ class Module extends Base
   init: (options = {}) -> 
       
       # Construct MVC index.
-      # get = (fn) -> fn '', throw:false
       get = Module.requireMvcIndex
       @index =
           models:      get @require.model
@@ -94,7 +93,14 @@ Module.requireMvcIndex = (fnRequirePart) ->
     
     # Silently try to get the 'index' of the MVC part.
     index = fnRequirePart '', throw: false
+    return index unless index?
     
+    # If the [index] is a funciton, it is expected that this is an initialization
+    # function.  Invoke it passing in the module.
+    index(fnRequirePart.module) if _.isFunction(index)
+    
+    # Finish up.
+    index
     
 
 

--- a/lib/src/open.server/config/configure.coffee
+++ b/lib/src/open.server/config/configure.coffee
@@ -49,6 +49,7 @@ module.exports = (app, options = {}) ->
               title:      'Open.Core Specs'
               url:        "#{baseUrl}/specs"
               specsDir:   "#{core.paths.test}/specs/client/"
+              samplesDir: "#{core.paths.test}/specs/client/samples"
               sourceUrls: [
                 "#{baseUrl}/libs.js"
                 "#{baseUrl}/core.js" ]

--- a/lib/src/open.server/routes/specs.coffee
+++ b/lib/src/open.server/routes/specs.coffee
@@ -11,17 +11,19 @@ Configures the Jasmine BDD spec runner.
         - specsDir    : The path to the directory containing the client-side specs.
         - sourceUrls  : An array or URLs (or a single URL) pointing to the source script(s)
                         that are under test.
+        - samplesDir:   Optional. The path to a directory of samples to compile and serve as commonJS modules.
 ###
 module.exports = (app, options) ->
-
+    
     # Setup initial conditions.
     core       = require 'open.server'
     url        = options.url ?= '/specs'
     title      = options.title ?= 'Specs'
     specsDir   = _.rtrim(options.specsDir ?= "#{process.env.PWD}/test/specs", '/')
+    samplesDir = _.rtrim(options.samplesDir, '/')if options.samplesDir?
     sourceUrls = options.sourceUrls ?= []
     sourceUrls = [sourceUrls] if not _.isArray(sourceUrls)
-
+    
     include = (file, endsWith) ->
         for ending in endsWith
           return true if _(file).endsWith(ending)
@@ -36,10 +38,10 @@ module.exports = (app, options) ->
               paths = _.map paths, (file) -> _(file).strRight(dir) if include(file, endsWith)
               paths = _.compact(paths)
               callback?(paths)
-
+    
     getSpecs   = (dir, callback) -> getFiles dir, ['_spec.coffee', '_spec.js'], callback
     getHelpers = (dir, callback) -> getFiles dir, ['_helper.coffee', '_helper.js'], callback
-
+    
     compileCoffee = (file, callback) ->
         fs.readFile file, 'utf8', (err, data) ->
             try
@@ -48,7 +50,7 @@ module.exports = (app, options) ->
               msg = "Failed to compile spec file: #{file} \n#{error.message}"
               throw msg
               
-
+    
     # Route: The test runner.
     app.get url, (req, res) ->
         getHelpers specsDir, (helperPaths) ->
@@ -62,25 +64,38 @@ module.exports = (app, options) ->
                                     specPaths:    specPaths
                                     helperPaths:  helperPaths
                                     sourceUrls:   sourceUrls
-
-
+                                    sampleCode:   "#{url}/samples"
+    
     # Route: The spec file.
     app.get "#{url}/specs/*", (req, res) ->
-
+        
         # Setup initial conditions.
         path = req.params[0]
         file = "#{specsDir}/#{req.params[0]}"
         extension = _(file).strRightBack('.')
-
+        
         if extension is 'js'
           # Send the standard JavaScript file.
           core.util.send.scriptFile res, file
         else if extension is 'coffee'
-
+         
           # Compile the coffee script.
           compileCoffee file, (script) -> core.util.send.script res, script
-
+          
         else
           # Unknown script type/
           res.send "Script type [.#{extension}] not supported", 415
+    
+    
+    # Route: Compiled sample code (CommonJS)
+    app.get "#{url}/samples", (req, res) ->
+        send = (code) -> core.util.send.script res, code
+        if not samplesDir?
+          send '' # No code to send.
+        else
+          path = 
+              path:      samplesDir
+              namespace: 'core/test'
+              deep:      true
+          new core.util.javascript.Builder(path).build (code) -> send code(false)
 

--- a/lib/views/specs/index.jade
+++ b/lib/views/specs/index.jade
@@ -11,7 +11,10 @@ html(lang="en")
     // Source files (under test).
     - each path in sourceUrls
       script(type='text/javascript', src="#{path}")
-
+    
+    // Sample code (compile into CommonJS modules).
+    script(type='text/javascript', src="#{sampleCode}")
+    
     // Helper files.
     - each path in helperPaths
       script(type='text/javascript', src="#{url}/specs/#{path}")

--- a/test/specs/client/core/mvc/module_spec.coffee
+++ b/test/specs/client/core/mvc/module_spec.coffee
@@ -159,7 +159,7 @@ describe 'mvc/module', ->
       spyOn(module, 'tryRequire').andCallFake (name, options) -> { foo:123 }
       expect(Module.requireMvcIndex(module.require.view).foo).toEqual 123
     
-    it 'invokes the [index] function, passing in the [module] as the first argument', ->
+    it 'invokes the [index] as a function, passing in the [module] as the first argument', ->
       arg = null
       fnIndex = -> 
           return (m) -> arg = m

--- a/test/specs/client/core/mvc/module_spec.coffee
+++ b/test/specs/client/core/mvc/module_spec.coffee
@@ -22,8 +22,7 @@ describe 'mvc/module', ->
     expect(module.modulePath).toEqual 'modules/foo'
   
   
-  
-  describe 'require', ->
+  describe '[require] mvc part methods', ->
     args = null
     beforeEach ->
         args = null
@@ -44,6 +43,17 @@ describe 'mvc/module', ->
       module.require.controller 'bar'
       expect(args.name).toEqual 'modules/foo/controllers/bar'
       expect(args.options.throw).toEqual true
+    
+    describe 'storing module reference on MVC part function', ->
+      it 'store modules on [model] require function', ->
+        expect(module.require.model.module).toEqual module
+
+      it 'store modules on [view] require function', ->
+        expect(module.require.view.module).toEqual module
+
+      it 'store modules on [controller] require function', ->
+        expect(module.require.controller.module).toEqual module
+    
     
   describe 'init', ->
     args = []
@@ -96,31 +106,27 @@ describe 'mvc/module', ->
         options = within: elBody
         module.init(options)
         expect(options.within).toEqual $(elBody)
-        
       
-        
-      
-      
-    
   
-  describe 'index', ->
+  describe 'index (the MVC conventional structure)', ->
     beforeEach ->
       spyOn(module, 'tryRequire').andCallFake (name, options) -> 
             return 'models_modules' if name is 'modules/foo/models/'
             return 'views_modules' if name is 'modules/foo/views/'
             return 'controllers_modules' if name is 'modules/foo/controllers/'
 
-    it 'stores the [models] index', ->
-      module.init()
-      expect(module.index.models).toEqual 'models_modules'
+    describe 'calling index for each MVC folder', ->
+      it 'stores the [models] index', ->
+        module.init()
+        expect(module.index.models).toEqual 'models_modules'
 
-    it 'stores the [views] index', ->
-      module.init()
-      expect(module.index.views).toEqual 'views_modules'
+      it 'stores the [views] index', ->
+        module.init()
+        expect(module.index.views).toEqual 'views_modules'
 
-    it 'stores the [controllers] index', ->
-      module.init()
-      expect(module.index.controllers).toEqual 'controllers_modules'
+      it 'stores the [controllers] index', ->
+        module.init()
+        expect(module.index.controllers).toEqual 'controllers_modules'
     
 
 

--- a/test/specs/client/core/mvc/module_spec.coffee
+++ b/test/specs/client/core/mvc/module_spec.coffee
@@ -144,7 +144,33 @@ describe 'mvc/module', ->
       it 'calls [requireMvcIndex] for controller', ->
         expect(spyCalls[2].args[0]).toEqual module.require.controller
         
-        
+  describe '[requireMvcIndex] static method', ->
+    it 'does not fail when the MVC part does not exist', ->
+      spyOn(module, 'tryRequire').andCallThrough()
+      expect(-> Module.requireMvcIndex(module.require.model)).not.toThrow()
+      expect(module.tryRequire.mostRecentCall.args[1].throw).toEqual false
+
+    it 'returns null if the MVC part does not exist', ->
+      fnRequire = -> undefined
+      result = Module.requireMvcIndex(fnRequire)
+      expect(result).toEqual undefined
+    
+    it 'does nothing if the [index] is a simple object', ->
+      spyOn(module, 'tryRequire').andCallFake (name, options) -> { foo:123 }
+      expect(Module.requireMvcIndex(module.require.view).foo).toEqual 123
+    
+    it 'invokes the [index] function, passing in the [module] as the first argument', ->
+      arg = null
+      fnIndex = -> 
+          return (m) -> arg = m
+      fnIndex.module = module
+
+      Module.requireMvcIndex(fnIndex)
+      expect(arg).toEqual module
+      
+      
+      
+      
 
 
 

--- a/test/specs/client/core/mvc/module_spec.coffee
+++ b/test/specs/client/core/mvc/module_spec.coffee
@@ -128,36 +128,36 @@ describe 'mvc/module', ->
         module.init()
         expect(module.index.controllers).toEqual 'controllers_modules'
     
-    describe 'getting the [index] of each MVC part via the static [requireMvcIndex] method', ->
+    describe 'getting the [index] of each MVC part via the static [requirePart] method', ->
       spyCalls = null
       beforeEach ->
-        spyOn(Module, 'requireMvcIndex').andCallThrough()
+        spyOn(Module, 'requirePart').andCallThrough()
         module.init()
-        spyCalls = Module.requireMvcIndex.calls
+        spyCalls = Module.requirePart.calls
       
-      it 'calls [requireMvcIndex] for model', ->
+      it 'calls [requirePart] for model', ->
         expect(spyCalls[0].args[0]).toEqual module.require.model
 
-      it 'calls [requireMvcIndex] for view', ->
+      it 'calls [requirePart] for view', ->
         expect(spyCalls[1].args[0]).toEqual module.require.view
 
-      it 'calls [requireMvcIndex] for controller', ->
+      it 'calls [requirePart] for controller', ->
         expect(spyCalls[2].args[0]).toEqual module.require.controller
         
-  describe '[requireMvcIndex] static method', ->
+  describe '[requirePart] static method', ->
     it 'does not fail when the MVC part does not exist', ->
       spyOn(module, 'tryRequire').andCallThrough()
-      expect(-> Module.requireMvcIndex(module.require.model)).not.toThrow()
+      expect(-> Module.requirePart(module.require.model)).not.toThrow()
       expect(module.tryRequire.mostRecentCall.args[1].throw).toEqual false
 
     it 'returns null if the MVC part does not exist', ->
       fnRequire = -> undefined
-      result = Module.requireMvcIndex(fnRequire)
+      result = Module.requirePart(fnRequire)
       expect(result).toEqual undefined
     
     it 'does nothing if the [index] is a simple object', ->
       spyOn(module, 'tryRequire').andCallFake (name, options) -> { foo:123 }
-      expect(Module.requireMvcIndex(module.require.view).foo).toEqual 123
+      expect(Module.requirePart(module.require.view).foo).toEqual 123
     
     it 'invokes the [index] as a function, passing in the [module] as the first argument', ->
       arg = null
@@ -165,16 +165,32 @@ describe 'mvc/module', ->
           return (m) -> arg = m
       fnIndex.module = module
 
-      Module.requireMvcIndex(fnIndex)
+      Module.requirePart(fnIndex)
       expect(arg).toEqual module
+  
+  describe 'setting default [views]', ->
+    module1 = null
+    views   = null
+    beforeEach ->
+        Module1 = require('core/test/modules/module1')
+        module1 = new Module1()
+        module1.init()
+        views = module1.index.views
     
+    it 'has a [views] index', ->
+      expect(views).toBeDefined()
+
+    it 'initializes the [views] index with the module', ->
+      expect(views.module).toEqual module1
     
-    it 'LOAD MODULE', ->
+    # it 'has a [root] view', ->
+    #   # TEMP 
+    #   console.log 'module1', module1
+    #   console.log 'module1.views', module1.index.views
       
-      foo = require 'core/test/foo'
-      console.log 'foo', foo
-      
     
+    
+  
     
       
       

--- a/test/specs/client/core/mvc/module_spec.coffee
+++ b/test/specs/client/core/mvc/module_spec.coffee
@@ -191,6 +191,17 @@ describe 'mvc/module', ->
       Tmpl = views.Tmpl
       tmpl = new Tmpl
       expect(tmpl.root instanceof Function).toEqual true 
+    
+    it 'does not have any default views', ->
+        Module2 = require('core/test/modules/module2')
+        module2 = new Module2()
+        module2.init()
+        views = module2.index.views
+        expect(views).toBeDefined()
+        expect(views.root).not.toBeDefined()
+        expect(views.tmpl).not.toBeDefined()
+      
+    
       
 
 

--- a/test/specs/client/core/mvc/module_spec.coffee
+++ b/test/specs/client/core/mvc/module_spec.coffee
@@ -167,7 +167,15 @@ describe 'mvc/module', ->
 
       Module.requireMvcIndex(fnIndex)
       expect(arg).toEqual module
+    
+    
+    it 'LOAD MODULE', ->
       
+      foo = require 'core/test/foo'
+      console.log 'foo', foo
+      
+    
+    
       
       
       

--- a/test/specs/client/core/mvc/module_spec.coffee
+++ b/test/specs/client/core/mvc/module_spec.coffee
@@ -183,17 +183,14 @@ describe 'mvc/module', ->
     it 'initializes the [views] index with the module', ->
       expect(views.module).toEqual module1
     
-    # it 'has a [root] view', ->
-    #   # TEMP 
-    #   console.log 'module1', module1
-    #   console.log 'module1.views', module1.index.views
-      
+    it 'has a [Root] view, initialized with the partent module', ->
+      expect(views.Root).toBeDefined()
+      expect(views.Root.module).toEqual module1
     
-    
-  
-    
-      
-      
+    it 'has a [tmpl] object', ->
+      Tmpl = views.Tmpl
+      tmpl = new Tmpl
+      expect(tmpl.root instanceof Function).toEqual true 
       
 
 

--- a/test/specs/client/core/mvc/module_spec.coffee
+++ b/test/specs/client/core/mvc/module_spec.coffee
@@ -108,13 +108,13 @@ describe 'mvc/module', ->
         expect(options.within).toEqual $(elBody)
       
   
-  describe 'index (the MVC conventional structure)', ->
+  describe 'index of the MVC conventional structure', ->
     beforeEach ->
       spyOn(module, 'tryRequire').andCallFake (name, options) -> 
             return 'models_modules' if name is 'modules/foo/models/'
             return 'views_modules' if name is 'modules/foo/views/'
             return 'controllers_modules' if name is 'modules/foo/controllers/'
-
+      
     describe 'calling index for each MVC folder', ->
       it 'stores the [models] index', ->
         module.init()
@@ -128,6 +128,23 @@ describe 'mvc/module', ->
         module.init()
         expect(module.index.controllers).toEqual 'controllers_modules'
     
+    describe 'getting the [index] of each MVC part via the static [requireMvcIndex] method', ->
+      spyCalls = null
+      beforeEach ->
+        spyOn(Module, 'requireMvcIndex').andCallThrough()
+        module.init()
+        spyCalls = Module.requireMvcIndex.calls
+      
+      it 'calls [requireMvcIndex] for model', ->
+        expect(spyCalls[0].args[0]).toEqual module.require.model
+
+      it 'calls [requireMvcIndex] for view', ->
+        expect(spyCalls[1].args[0]).toEqual module.require.view
+
+      it 'calls [requireMvcIndex] for controller', ->
+        expect(spyCalls[2].args[0]).toEqual module.require.controller
+        
+        
 
 
 

--- a/test/specs/client/samples/foo.coffee
+++ b/test/specs/client/samples/foo.coffee
@@ -1,0 +1,1 @@
+console.log 'foo sample', 123

--- a/test/specs/client/samples/foo.coffee
+++ b/test/specs/client/samples/foo.coffee
@@ -1,1 +1,0 @@
-console.log 'foo sample', 123

--- a/test/specs/client/samples/modules/module1/index.coffee
+++ b/test/specs/client/samples/modules/module1/index.coffee
@@ -1,0 +1,5 @@
+
+module.exports = class Module1 extends core.mvc.Module
+  constructor: (args) -> 
+      super 'core/test/modules/module1'
+      

--- a/test/specs/client/samples/modules/module1/views/index.coffee
+++ b/test/specs/client/samples/modules/module1/views/index.coffee
@@ -1,0 +1,3 @@
+module.exports = (module) -> 
+  index =
+    module: module

--- a/test/specs/client/samples/modules/module1/views/root.coffee
+++ b/test/specs/client/samples/modules/module1/views/root.coffee
@@ -1,0 +1,6 @@
+# NOTE: Implements the module-init pattern.
+
+module.exports = (module) ->
+  root =
+    module: module
+  

--- a/test/specs/client/samples/modules/module1/views/tmpl.coffee
+++ b/test/specs/client/samples/modules/module1/views/tmpl.coffee
@@ -1,0 +1,8 @@
+# NOTE: Does not implement the module-init pattern.
+
+module.exports = class MyTmpl extends core.mvc.Template
+  root: 
+    """
+    <h1>Root Template</h1>
+    """
+    

--- a/test/specs/client/samples/modules/module2/index.coffee
+++ b/test/specs/client/samples/modules/module2/index.coffee
@@ -1,0 +1,5 @@
+
+module.exports = class Module2 extends core.mvc.Module
+  constructor: (args) -> 
+      super 'core/test/modules/module2'
+      

--- a/test/specs/client/samples/modules/module2/views/index.coffee
+++ b/test/specs/client/samples/modules/module2/views/index.coffee
@@ -1,0 +1,3 @@
+module.exports = (module) -> 
+  index =
+    module: module


### PR DESCRIPTION
Not sure if you wanna see this - it's `open.core` - but I think that was the general idea when you suggested being added to `open.core` as a collaborator.

So this pull request is really all about laying on some **conventions** into the module.

The Module, when the `init` method is called, builds up an index of the MVC structures within itself, based on the conventional folders
- /models
- /views
- /controllers

There are some common views that are repeated all the time across modules, namely:
- `root` - the Root view of the module (sometimes the only one).
- `tmpl` - Stricktly speaking not a `View` because it's a `Template` but it sits next to the views and is used by them.

Now with this pull request, the Module automatically populates them onto the `Module.index.views` structure IF they exist.  Meaning this is one less "setup / configuration" thing the consumer has to do.  They just lay out the folder structure, put in their `Root` and `Tmpl` files in and whala - it's available for use off the `Module`. 
